### PR TITLE
Restore 'zip end header not found' note

### DIFF
--- a/patient-generated-data-synthetic/README.md
+++ b/patient-generated-data-synthetic/README.md
@@ -12,3 +12,18 @@ Use `docker container ls` to verify that the `pgd-db` image is running.
 
 The resulting SQL Server instance is available at `localhost:1633`,
 username `SA` and password `<YourStrong!Passw0rd>`.
+
+To resolve
+`error reading liquibase-core.jar; zip END header not found`,
+download the artifact from
+[Maven Central](https://search.maven.org/artifact/org.liquibase/liquibase-core/3.8.9/jar)
+and install manually:
+
+```
+mvn install:install-file \
+  -Dfile=/path/to/liquibase-core-3.8.9.jar \
+  -DgroupId=org.liquibase \
+  -DartifactId=liquibase-core \
+  -Dversion=3.8.9 \
+  -Dpackaging=jar
+```


### PR DESCRIPTION
Restore the note in the synthetic data README about `zip end header not found`; this was unknowingly lost in a merge