### PR TITLE
API-3945 OAuth support

### DIFF
--- a/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/ObservationIT.java
+++ b/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/ObservationIT.java
@@ -10,12 +10,11 @@ import org.junit.jupiter.api.Test;
 public class ObservationIT {
   @BeforeAll
   static void assumeEnvironment() {
-    assumeEnvironmentIn(
-        Environment.LOCAL,
-        Environment.QA,
-        Environment.STAGING,
-        Environment.STAGING_LAB,
-        Environment.LAB);
+    assumeEnvironmentIn(Environment.LOCAL);
+    //  Environment.QA,
+    //  Environment.STAGING,
+    //  Environment.STAGING_LAB,
+    //  Environment.LAB
   }
 
   @Test

--- a/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/PatientIT.java
+++ b/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/PatientIT.java
@@ -10,12 +10,11 @@ import org.junit.jupiter.api.Test;
 public class PatientIT {
   @BeforeAll
   static void assumeEnvironment() {
-    assumeEnvironmentIn(
-        Environment.LOCAL,
-        Environment.QA,
-        Environment.STAGING,
-        Environment.STAGING_LAB,
-        Environment.LAB);
+    assumeEnvironmentIn(Environment.LOCAL);
+    //        Environment.QA,
+    //        Environment.STAGING,
+    //        Environment.STAGING_LAB,
+    //        Environment.LAB
   }
 
   @Test

--- a/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/QuestionnaireIT.java
+++ b/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/QuestionnaireIT.java
@@ -10,12 +10,11 @@ import org.junit.jupiter.api.Test;
 public class QuestionnaireIT {
   @BeforeAll
   static void assumeEnvironment() {
-    assumeEnvironmentIn(
-        Environment.LOCAL,
-        Environment.QA,
-        Environment.STAGING,
-        Environment.STAGING_LAB,
-        Environment.LAB);
+    assumeEnvironmentIn(Environment.LOCAL);
+    //    Environment.QA,
+    //    Environment.STAGING,
+    //    Environment.STAGING_LAB,
+    //    Environment.LAB
   }
 
   @Test

--- a/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/QuestionnaireResponseIT.java
+++ b/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/QuestionnaireResponseIT.java
@@ -10,12 +10,11 @@ import org.junit.jupiter.api.Test;
 public class QuestionnaireResponseIT {
   @BeforeAll
   static void assumeEnvironment() {
-    assumeEnvironmentIn(
-        Environment.LOCAL,
-        Environment.QA,
-        Environment.STAGING,
-        Environment.STAGING_LAB,
-        Environment.LAB);
+    assumeEnvironmentIn(Environment.LOCAL);
+    //    Environment.QA,
+    //    Environment.STAGING,
+    //    Environment.STAGING_LAB,
+    //    Environment.LAB
   }
 
   @Test

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
@@ -1,0 +1,117 @@
+package gov.va.api.health.patientgenerateddata;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import gov.va.api.health.r4.api.elements.Reference;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidParameterException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.servlet.http.HttpServletResponse;
+import lombok.Builder;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * This class contains the logic for implementing, on a per-resource basis, a ResponseBodyAdvice as
+ * an @ControllerAdvice.
+ *
+ * <p>The @ControllerAdvice's intercept all responses from Controller @RequestMappings. The advice
+ * then checks the return type of the @RequestMapping's payload. If it is "supported", (see the
+ * supports() method), then beforeBodyWrite() logic fires. It will search the payload using a
+ * supplied ICN extraction function. We then populate an internal header of X-VA-INCLUDES-ICN with
+ * the corresponding ICN(s) in the payload. This header will be used by Kong to do Authorization via
+ * Patient Matching.
+ */
+@Builder
+public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> {
+  public static final String INCLUDES_ICN_HEADER = "X-VA-INCLUDES-ICN";
+
+  private final Class<T> type;
+
+  private final Class<B> bundleType;
+
+  private final Function<B, Stream<T>> extractResources;
+
+  private final Function<T, Stream<String>> extractIcns;
+
+  /** Add the X-VA-INCLUDES-ICN header if it does not already exist. */
+  public static void addHeader(ServerHttpResponse serverHttpResponse, String usersCsv) {
+    HttpHeaders headers = serverHttpResponse != null ? serverHttpResponse.getHeaders() : null;
+    if (headers == null
+        || headers.get(INCLUDES_ICN_HEADER) == null
+        || headers.get(INCLUDES_ICN_HEADER).isEmpty()) {
+      serverHttpResponse.getHeaders().add(INCLUDES_ICN_HEADER, usersCsv);
+    }
+  }
+
+  /** Add the X-VA-INCLUDES-ICN header if it does not already exist. */
+  public static void addHeader(HttpServletResponse serverHttpResponse, String usersCsv) {
+    if (isBlank(serverHttpResponse.getHeader(INCLUDES_ICN_HEADER))) {
+      serverHttpResponse.addHeader(INCLUDES_ICN_HEADER, usersCsv);
+    }
+  }
+
+  public static void addHeaderForNoPatients(HttpServletResponse serverHttpResponse) {
+    addHeader(serverHttpResponse, "NONE");
+  }
+
+  public static String encodeHeaderValue(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  /** Extract patient ICN from reference. */
+  public static String icn(Reference reference) {
+    if ("patient".equalsIgnoreCase(ReferenceUtils.resourceType(reference))) {
+      return ReferenceUtils.resourceId(reference);
+    }
+    return null;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Object beforeBodyWrite(
+      Object payload,
+      MethodParameter unused1,
+      MediaType unused2,
+      Class<? extends HttpMessageConverter<?>> unused3,
+      ServerHttpRequest unused4,
+      ServerHttpResponse serverHttpResponse) {
+    // In the case where extractIcns is null, let Kong deal with it
+    if (extractIcns == null) {
+      return payload;
+    }
+    String users = "";
+    if (type.isInstance(payload)) {
+      users = extractIcns.apply((T) payload).collect(Collectors.joining());
+    } else if (bundleType.isInstance(payload)) {
+      users =
+          extractResources
+              .apply((B) payload)
+              .flatMap(resource -> extractIcns.apply(resource))
+              .distinct()
+              .collect(Collectors.joining(","));
+    } else {
+      throw new InvalidParameterException("Payload type does not match ControllerAdvice type.");
+    }
+    if (users.isBlank()) {
+      users = "NONE";
+    }
+    addHeader(serverHttpResponse, users);
+    return payload;
+  }
+
+  @Override
+  public boolean supports(
+      MethodParameter methodParameter, Class<? extends HttpMessageConverter<?>> unused) {
+    return type.equals(methodParameter.getParameterType())
+        || bundleType.equals(methodParameter.getParameterType());
+  }
+}

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
@@ -1,6 +1,5 @@
 package gov.va.api.health.patientgenerateddata;
 
-
 import gov.va.api.health.r4.api.elements.Reference;
 import java.security.InvalidParameterException;
 import java.util.function.Function;
@@ -15,17 +14,6 @@ import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-/**
- * This class contains the logic for implementing, on a per-resource basis, a ResponseBodyAdvice as
- * an @ControllerAdvice.
- *
- * <p>The @ControllerAdvice's intercept all responses from Controller @RequestMappings. The advice
- * then checks the return type of the @RequestMapping's payload. If it is "supported", (see the
- * supports() method), then beforeBodyWrite() logic fires. It will search the payload using a
- * supplied ICN extraction function. We then populate an internal header of X-VA-INCLUDES-ICN with
- * the corresponding ICN(s) in the payload. This header will be used by Kong to do Authorization via
- * Patient Matching.
- */
 @Builder
 public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> {
   public static final String INCLUDES_ICN_HEADER = "X-VA-INCLUDES-ICN";
@@ -48,7 +36,7 @@ public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> 
     }
   }
 
-  /** Extract patient ICN from reference. */
+  /** Extract patient ICN from the reference. */
   public static String icn(Reference reference) {
     if ("patient".equalsIgnoreCase(ReferenceUtils.resourceType(reference))) {
       return ReferenceUtils.resourceId(reference);
@@ -65,7 +53,7 @@ public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> 
       Class<? extends HttpMessageConverter<?>> unused3,
       ServerHttpRequest unused4,
       ServerHttpResponse serverHttpResponse) {
-    // In the case where extractIcns is null, let Kong deal with it
+    // In the case where extractIcns is null, let Kong handle it
     if (extractIcns == null) {
       return payload;
     }

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
@@ -1,15 +1,11 @@
 package gov.va.api.health.patientgenerateddata;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.health.r4.api.elements.Reference;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidParameterException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.servlet.http.HttpServletResponse;
 import lombok.Builder;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -50,21 +46,6 @@ public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> 
         || headers.get(INCLUDES_ICN_HEADER).isEmpty()) {
       serverHttpResponse.getHeaders().add(INCLUDES_ICN_HEADER, usersCsv);
     }
-  }
-
-  /** Add the X-VA-INCLUDES-ICN header if it does not already exist. */
-  public static void addHeader(HttpServletResponse serverHttpResponse, String usersCsv) {
-    if (isBlank(serverHttpResponse.getHeader(INCLUDES_ICN_HEADER))) {
-      serverHttpResponse.addHeader(INCLUDES_ICN_HEADER, usersCsv);
-    }
-  }
-
-  public static void addHeaderForNoPatients(HttpServletResponse serverHttpResponse) {
-    addHeader(serverHttpResponse, "NONE");
-  }
-
-  public static String encodeHeaderValue(String value) {
-    return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 
   /** Extract patient ICN from reference. */

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/ReferenceUtils.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/ReferenceUtils.java
@@ -1,0 +1,55 @@
+package gov.va.api.health.patientgenerateddata;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import com.google.common.base.Splitter;
+import gov.va.api.health.r4.api.elements.Reference;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class ReferenceUtils {
+  /**
+   * Extract resource ID. This is looking for any number of path elements, then a resource type
+   * followed by an ID, e.g. `foo/bar/Patient/1234567890V123456`.
+   */
+  public static String resourceId(Reference ref) {
+    if (ref == null || isBlank(ref.reference())) {
+      return null;
+    }
+    List<String> splitReference = Splitter.on('/').splitToList(ref.reference());
+    if (splitReference.size() <= 1) {
+      return null;
+    }
+    if (isBlank(splitReference.get(splitReference.size() - 2))) {
+      return null;
+    }
+    String resourceId = splitReference.get(splitReference.size() - 1);
+    if (isBlank(resourceId)) {
+      return null;
+    }
+    return resourceId;
+  }
+
+  /**
+   * Extract resource type. This is looking for any number of path elements, then a resource type
+   * followed by an ID, e.g. `foo/bar/Patient/1234567890V123456`.
+   */
+  public static String resourceType(Reference ref) {
+    if (ref == null || isBlank(ref.reference())) {
+      return null;
+    }
+    List<String> splitReference = Splitter.on('/').splitToList(ref.reference());
+    if (splitReference.size() <= 1) {
+      return null;
+    }
+    if (isBlank(splitReference.get(splitReference.size() - 1))) {
+      return null;
+    }
+    String resourceType = splitReference.get(splitReference.size() - 2);
+    if (isBlank(resourceType)) {
+      return null;
+    }
+    return resourceType;
+  }
+}

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/SerializationUtils.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/SerializationUtils.java
@@ -3,7 +3,9 @@ package gov.va.api.health.patientgenerateddata;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import lombok.NonNull;
 import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 public class SerializationUtils {
   /** Deserialized Payload. */
   @SneakyThrows

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/observation/ObservationIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/observation/ObservationIncludesIcnMajig.java
@@ -8,10 +8,6 @@ import lombok.experimental.Delegate;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-/**
- * Intercept all Observation RequestMapping payloads. Extract ICNs with the provided function. These
- * will be used to populate the X-VA-INCLUDES-ICN header.
- */
 @ControllerAdvice
 public class ObservationIncludesIcnMajig implements ResponseBodyAdvice<Object> {
   @Delegate

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/observation/ObservationIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/observation/ObservationIncludesIcnMajig.java
@@ -1,0 +1,25 @@
+package gov.va.api.health.patientgenerateddata.observation;
+
+import gov.va.api.health.patientgenerateddata.IncludesIcnMajig;
+import gov.va.api.health.r4.api.bundle.AbstractEntry;
+import gov.va.api.health.r4.api.resources.Observation;
+import java.util.stream.Stream;
+import lombok.experimental.Delegate;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Intercept all Observation RequestMapping payloads. Extract ICNs with the provided function. These
+ * will be used to populate the X-VA-INCLUDES-ICN header.
+ */
+@ControllerAdvice
+public class ObservationIncludesIcnMajig implements ResponseBodyAdvice<Object> {
+  @Delegate
+  private final ResponseBodyAdvice<Object> delegate =
+      IncludesIcnMajig.<Observation, Observation.Bundle>builder()
+          .type(Observation.class)
+          .bundleType(Observation.Bundle.class)
+          .extractResources(bundle -> bundle.entry().stream().map(AbstractEntry::resource))
+          .extractIcns(body -> Stream.ofNullable(IncludesIcnMajig.icn(body.subject())))
+          .build();
+}

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/patient/PatientIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/patient/PatientIncludesIcnMajig.java
@@ -8,10 +8,6 @@ import lombok.experimental.Delegate;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-/**
- * Intercept all Patient RequestMapping payloads. Extract ICNs with the provided function. These
- * will be used to populate the X-VA-INCLUDES-ICN header.
- */
 @ControllerAdvice
 public class PatientIncludesIcnMajig implements ResponseBodyAdvice<Object> {
   @Delegate

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/patient/PatientIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/patient/PatientIncludesIcnMajig.java
@@ -1,0 +1,25 @@
+package gov.va.api.health.patientgenerateddata.patient;
+
+import gov.va.api.health.patientgenerateddata.IncludesIcnMajig;
+import gov.va.api.health.r4.api.bundle.AbstractEntry;
+import gov.va.api.health.r4.api.resources.Patient;
+import java.util.stream.Stream;
+import lombok.experimental.Delegate;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Intercept all Patient RequestMapping payloads. Extract ICNs with the provided function. These
+ * will be used to populate the X-VA-INCLUDES-ICN header.
+ */
+@ControllerAdvice
+public class PatientIncludesIcnMajig implements ResponseBodyAdvice<Object> {
+  @Delegate
+  private final ResponseBodyAdvice<Object> delegate =
+      IncludesIcnMajig.<Patient, Patient.Bundle>builder()
+          .type(Patient.class)
+          .bundleType(Patient.Bundle.class)
+          .extractResources(bundle -> bundle.entry().stream().map(AbstractEntry::resource))
+          .extractIcns(body -> Stream.of(body.id()))
+          .build();
+}

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaire/QuestionnaireIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaire/QuestionnaireIncludesIcnMajig.java
@@ -8,10 +8,6 @@ import lombok.experimental.Delegate;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-/**
- * Intercept all Questionnaire RequestMapping payloads. Extract ICNs with the provided function.
- * These will be used to populate the X-VA-INCLUDES-ICN header.
- */
 @ControllerAdvice
 public class QuestionnaireIncludesIcnMajig implements ResponseBodyAdvice<Object> {
   @Delegate

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaire/QuestionnaireIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaire/QuestionnaireIncludesIcnMajig.java
@@ -1,0 +1,25 @@
+package gov.va.api.health.patientgenerateddata.questionnaire;
+
+import gov.va.api.health.patientgenerateddata.IncludesIcnMajig;
+import gov.va.api.health.r4.api.bundle.AbstractEntry;
+import gov.va.api.health.r4.api.resources.Questionnaire;
+import java.util.stream.Stream;
+import lombok.experimental.Delegate;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Intercept all Questionnaire RequestMapping payloads. Extract ICNs with the provided function.
+ * These will be used to populate the X-VA-INCLUDES-ICN header.
+ */
+@ControllerAdvice
+public class QuestionnaireIncludesIcnMajig implements ResponseBodyAdvice<Object> {
+  @Delegate
+  private final ResponseBodyAdvice<Object> delegate =
+      IncludesIcnMajig.<Questionnaire, Questionnaire.Bundle>builder()
+          .type(Questionnaire.class)
+          .bundleType(Questionnaire.Bundle.class)
+          .extractResources(bundle -> bundle.entry().stream().map(AbstractEntry::resource))
+          .extractIcns(body -> Stream.empty())
+          .build();
+}

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
@@ -1,0 +1,29 @@
+package gov.va.api.health.patientgenerateddata.questionnaireresponse;
+
+import gov.va.api.health.patientgenerateddata.IncludesIcnMajig;
+import gov.va.api.health.r4.api.bundle.AbstractEntry;
+import gov.va.api.health.r4.api.resources.QuestionnaireResponse;
+import java.util.stream.Stream;
+import lombok.experimental.Delegate;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Intercept all QuestionnaireResponse RequestMapping payloads. Extract ICNs with the provided
+ * function. These will be used to populate the X-VA-INCLUDES-ICN header.
+ */
+@ControllerAdvice
+public class QuestionnaireResponseIncludesIcnMajig implements ResponseBodyAdvice<Object> {
+  @Delegate
+  private final ResponseBodyAdvice<Object> delegate =
+      IncludesIcnMajig.<QuestionnaireResponse, QuestionnaireResponse.Bundle>builder()
+          .type(QuestionnaireResponse.class)
+          .bundleType(QuestionnaireResponse.Bundle.class)
+          .extractResources(bundle -> bundle.entry().stream().map(AbstractEntry::resource))
+          .extractIcns(
+              body ->
+                  Stream.concat(
+                      Stream.ofNullable(IncludesIcnMajig.icn(body.subject())),
+                      Stream.ofNullable(IncludesIcnMajig.icn(body.author()))))
+          .build();
+}

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
@@ -8,10 +8,6 @@ import lombok.experimental.Delegate;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-/**
- * Intercept all QuestionnaireResponse RequestMapping payloads. Extract ICNs with the provided
- * function. These will be used to populate the X-VA-INCLUDES-ICN header.
- */
 @ControllerAdvice
 public class QuestionnaireResponseIncludesIcnMajig implements ResponseBodyAdvice<Object> {
   @Delegate

--- a/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajigTest.java
+++ b/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajigTest.java
@@ -1,0 +1,194 @@
+package gov.va.api.health.patientgenerateddata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import gov.va.api.health.r4.api.bundle.AbstractBundle;
+import gov.va.api.health.r4.api.bundle.AbstractEntry;
+import gov.va.api.health.r4.api.bundle.BundleLink;
+import gov.va.api.health.r4.api.datatypes.Identifier;
+import gov.va.api.health.r4.api.datatypes.Signature;
+import gov.va.api.health.r4.api.elements.Extension;
+import gov.va.api.health.r4.api.elements.Meta;
+import gov.va.api.health.r4.api.resources.Resource;
+import java.security.InvalidParameterException;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.Delegate;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+public class IncludesIcnMajigTest {
+  @Test
+  public void beforeBodyWriteThrowsExceptionForUnsupportedType() {
+    Assertions.assertThrows(
+        InvalidParameterException.class,
+        () -> new FakeMajg().beforeBodyWrite(null, null, null, null, null, null));
+  }
+
+  @Test
+  public void icnHeaderIsPresentForResource() {
+    ServerHttpResponse mockResponse = mock(ServerHttpResponse.class);
+    HttpHeaders mockHeaders = mock(HttpHeaders.class);
+    when(mockResponse.getHeaders()).thenReturn(mockHeaders);
+    new FakeMajg()
+        .beforeBodyWrite(
+            FakeResource.builder().id("666V666").build(), null, null, null, null, mockResponse);
+    verify(mockHeaders, Mockito.atLeastOnce()).get("X-VA-INCLUDES-ICN");
+    verify(mockHeaders).add("X-VA-INCLUDES-ICN", "666V666");
+    verifyNoMoreInteractions(mockHeaders);
+  }
+
+  @Test
+  public void icnHeadersAreDistictValuesForResourceBundle() {
+    ServerHttpResponse mockResponse = mock(ServerHttpResponse.class);
+    HttpHeaders mockHeaders = mock(HttpHeaders.class);
+    when(mockResponse.getHeaders()).thenReturn(mockHeaders);
+    var payload =
+        FakeBundle.builder()
+            .entry(
+                List.of(
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("666V666").build())
+                        .build(),
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("777V777").build())
+                        .build(),
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("888V888").build())
+                        .build(),
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("666V666").build())
+                        .build(),
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("777V777").build())
+                        .build()))
+            .build();
+    new FakeMajg().beforeBodyWrite(payload, null, null, null, null, mockResponse);
+    verify(mockHeaders, Mockito.atLeastOnce()).get("X-VA-INCLUDES-ICN");
+    verify(mockHeaders).add("X-VA-INCLUDES-ICN", "666V666,777V777,888V888");
+    verifyNoMoreInteractions(mockHeaders);
+  }
+
+  @Test
+  public void icnHeadersArePresentForResourceBundle() {
+    ServerHttpResponse mockResponse = mock(ServerHttpResponse.class);
+    HttpHeaders mockHeaders = mock(HttpHeaders.class);
+    when(mockResponse.getHeaders()).thenReturn(mockHeaders);
+    var payload =
+        FakeBundle.builder()
+            .entry(
+                List.of(
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("666V666").build())
+                        .build(),
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("777V777").build())
+                        .build(),
+                    FakeEntry.builder()
+                        .resource(FakeResource.builder().id("888V888").build())
+                        .build()))
+            .build();
+    new FakeMajg().beforeBodyWrite(payload, null, null, null, null, mockResponse);
+    verify(mockHeaders, Mockito.atLeastOnce()).get("X-VA-INCLUDES-ICN");
+    verify(mockHeaders).add("X-VA-INCLUDES-ICN", "666V666,777V777,888V888");
+    verifyNoMoreInteractions(mockHeaders);
+  }
+
+  @Test
+  public void supportedAcceptsResourceOrResourceBundle() {
+    MethodParameter supportedResource = mock(MethodParameter.class);
+    doReturn(FakeResource.class).when(supportedResource).getParameterType();
+    assertThat(new FakeMajg().supports(supportedResource, null)).isTrue();
+    MethodParameter supportedResourceBundle = mock(MethodParameter.class);
+    doReturn(FakeBundle.class).when(supportedResourceBundle).getParameterType();
+    assertThat(new FakeMajg().supports(supportedResourceBundle, null)).isTrue();
+    MethodParameter unsupportedResource = mock(MethodParameter.class);
+    doReturn(String.class).when(unsupportedResource).getParameterType();
+    assertThat(new FakeMajg().supports(unsupportedResource, null)).isFalse();
+  }
+
+  /**
+   * Silly Test implementation of the AbstractIncludesIcnMajig.java Because we are using Templates,
+   * we also need a a fake Resource, Entry, and Bundle class
+   */
+  public static final class FakeMajg implements ResponseBodyAdvice<Object> {
+    @Delegate
+    private final ResponseBodyAdvice<Object> delegate =
+        IncludesIcnMajig.<FakeResource, FakeBundle>builder()
+            .type(FakeResource.class)
+            .bundleType(FakeBundle.class)
+            .extractResources(bundle -> bundle.entry().stream().map(AbstractEntry::resource))
+            .extractIcns(body -> Stream.of(body.id))
+            .build();
+  }
+
+  @Builder
+  @Data
+  static final class FakeResource implements Resource {
+    String id;
+
+    String implicitRules;
+
+    String language;
+
+    Meta meta;
+  }
+
+  static final class FakeEntry extends AbstractEntry<FakeResource> {
+    @Builder
+    FakeEntry(
+        String id,
+        List<Extension> extension,
+        List<Extension> modifierExtension,
+        List<BundleLink> link,
+        String fullUrl,
+        FakeResource resource,
+        Search search,
+        Request request,
+        Response response) {
+      super(id, extension, modifierExtension, link, fullUrl, resource, search, request, response);
+    }
+  }
+
+  static final class FakeBundle extends AbstractBundle<FakeEntry> {
+    @Builder
+    FakeBundle(
+        String resourceType,
+        String id,
+        Meta meta,
+        String implicitRules,
+        String language,
+        Identifier identifier,
+        BundleType type,
+        Integer total,
+        List<BundleLink> link,
+        List<FakeEntry> entry,
+        Signature signature) {
+      super(
+          resourceType,
+          id,
+          meta,
+          implicitRules,
+          language,
+          identifier,
+          type,
+          language,
+          total,
+          link,
+          entry,
+          signature);
+    }
+  }
+}

--- a/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/ReferenceUtilsTest.java
+++ b/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/ReferenceUtilsTest.java
@@ -1,0 +1,48 @@
+package gov.va.api.health.patientgenerateddata;
+
+import static gov.va.api.health.patientgenerateddata.ReferenceUtils.resourceId;
+import static gov.va.api.health.patientgenerateddata.ReferenceUtils.resourceType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.api.health.r4.api.elements.Reference;
+import org.junit.jupiter.api.Test;
+
+public class ReferenceUtilsTest {
+  @Test
+  void resourceId_null() {
+    assertThat(resourceId(Reference.builder().build())).isNull();
+    assertThat(resourceId(Reference.builder().reference("no").build())).isNull();
+    assertThat(resourceId(Reference.builder().reference("/no").build())).isNull();
+    assertThat(resourceId(Reference.builder().reference("no/").build())).isNull();
+    assertThat(resourceId(Reference.builder().reference("no/ ").build())).isNull();
+    assertThat(resourceId(Reference.builder().reference("whatever/no/").build())).isNull();
+    assertThat(resourceId(Reference.builder().reference("/whatever/no/").build())).isNull();
+  }
+
+  @Test
+  void resourceId_valid() {
+    assertThat(resourceId(Reference.builder().reference("/Patient/123V456").build()))
+        .isEqualTo("123V456");
+    assertThat(resourceId(Reference.builder().reference("Patient/123V456").build()))
+        .isEqualTo("123V456");
+  }
+
+  @Test
+  void resourceType_null() {
+    assertThat(resourceType(Reference.builder().build())).isNull();
+    assertThat(resourceType(Reference.builder().reference("no").build())).isNull();
+    assertThat(resourceType(Reference.builder().reference("/no").build())).isNull();
+    assertThat(resourceType(Reference.builder().reference("no/").build())).isNull();
+    assertThat(resourceType(Reference.builder().reference("no/ ").build())).isNull();
+    assertThat(resourceType(Reference.builder().reference("whatever/no/").build())).isNull();
+    assertThat(resourceType(Reference.builder().reference("/whatever/no/").build())).isNull();
+  }
+
+  @Test
+  void resourceType_valid() {
+    assertThat(resourceType(Reference.builder().reference("/patient/123V456").build()))
+        .isEqualTo("patient");
+    assertThat(resourceType(Reference.builder().reference("patient/123V456").build()))
+        .isEqualTo("patient");
+  }
+}


### PR DESCRIPTION
To support https://github.com/department-of-veterans-affairs/health-apis-patient-generated-data-deployment/pull/11:

- Make resource-based integration tests local-only (I expect authentication will interfere with these. I will evaluate how to re-enable the ITs in the Kubernetes environments once there are successful deployments incorporating both PRs)

- To support the `health-apis-patient-matching` Kong plugin, implement `IncludesIcnMajig` for each resource, following data-query's example