### PR TITLE
API-4020 set X-VA-INCLUDES-ICN header for patient updates

### DIFF
--- a/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajigTest.java
+++ b/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajigTest.java
@@ -15,13 +15,11 @@ import gov.va.api.health.r4.api.datatypes.Signature;
 import gov.va.api.health.r4.api.elements.Extension;
 import gov.va.api.health.r4.api.elements.Meta;
 import gov.va.api.health.r4.api.resources.Resource;
-import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.Data;
 import lombok.experimental.Delegate;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.MethodParameter;
@@ -30,13 +28,6 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 public class IncludesIcnMajigTest {
-  @Test
-  public void beforeBodyWriteThrowsExceptionForUnsupportedType() {
-    Assertions.assertThrows(
-        InvalidParameterException.class,
-        () -> new FakeMajg().beforeBodyWrite(null, null, null, null, null, null));
-  }
-
   @Test
   public void icnHeaderIsPresentForResource() {
     ServerHttpResponse mockResponse = mock(ServerHttpResponse.class);

--- a/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/patient/PatientControllerTest.java
+++ b/patient-generated-data/src/test/java/gov/va/api/health/patientgenerateddata/patient/PatientControllerTest.java
@@ -10,10 +10,10 @@ import static org.mockito.Mockito.when;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.health.patientgenerateddata.Exceptions;
 import gov.va.api.health.r4.api.resources.Patient;
+import java.net.URI;
 import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.DataBinder;
 
@@ -50,7 +50,7 @@ public class PatientControllerTest {
     when(repo.findById("x"))
         .thenReturn(Optional.of(PatientEntity.builder().id("x").payload(payload).build()));
     assertThat(new PatientController(repo).update("x", patient))
-        .isEqualTo(ResponseEntity.ok().build());
+        .isEqualTo(ResponseEntity.ok(patient));
     verify(repo, times(1)).save(PatientEntity.builder().id("x").payload(payload).build());
   }
 
@@ -61,7 +61,7 @@ public class PatientControllerTest {
     Patient patient = Patient.builder().id("x").build();
     String payload = JacksonConfig.createMapper().writeValueAsString(patient);
     assertThat(new PatientController(repo).update("x", patient))
-        .isEqualTo(ResponseEntity.status(HttpStatus.CREATED).build());
+        .isEqualTo(ResponseEntity.created(URI.create("/r4/Patient/x")).body(patient));
     verify(repo, times(1)).save(PatientEntity.builder().id("x").payload(payload).build());
   }
 }


### PR DESCRIPTION
I suspect that the `502 bad gateway` status code emitted during updates in the Kubernetes environment is caused by the absence of the `X-VA-INCLUDES-ICN` header. This PR makes adds the original message payload to the response for patient updates (which we should be doing anyway: https://www.hl7.org/fhir/r4/http.html#return), and makes `IncludesIcnMajig` handle `ResponseEntity` method parameters. 

If this tests successfully for patient in QA, I will address the other resources in a subsequent PR.