### PR TITLE
API-4145 populate subject as patient in synthetic data

### DIFF
--- a/patient-generated-data-synthetic/src/test/resources/observation/ekg.json
+++ b/patient-generated-data-synthetic/src/test/resources/observation/ekg.json
@@ -14,7 +14,8 @@
           "code" : "procedure",
           "display" : "Procedure"
         }
-      ]
+      ],
+      "text" : "Procedure"
     }
   ],
   "code" : {
@@ -24,7 +25,8 @@
         "code" : "131328",
         "display" : "MDC_ECG_ELEC_POTL"
       }
-    ]
+    ],
+    "text" : "MDC_ECG_ELEC_POTL"
   },
   "subject" : {
     "reference" : "Patient/1011537977V693883",
@@ -49,7 +51,8 @@
             "code" : "131329",
             "display" : "MDC_ECG_ELEC_POTL_I"
           }
-        ]
+        ],
+        "text" : "MDC_ECG_ELEC_POTL_I"
       },
       "valueSampledData" : {
         "origin" : {
@@ -71,7 +74,8 @@
             "code" : "131330",
             "display" : "MDC_ECG_ELEC_POTL_II"
           }
-        ]
+        ],
+        "text" : "MDC_ECG_ELEC_POTL_II"
       },
       "valueSampledData" : {
         "origin" : {
@@ -93,7 +97,8 @@
             "code" : "131389",
             "display" : "MDC_ECG_ELEC_POTL_III"
           }
-        ]
+        ],
+        "text" : "MDC_ECG_ELEC_POTL_III"
       },
       "valueSampledData" : {
         "origin" : {

--- a/patient-generated-data-synthetic/src/test/resources/observation/ekg.json
+++ b/patient-generated-data-synthetic/src/test/resources/observation/ekg.json
@@ -29,7 +29,7 @@
     "text" : "MDC_ECG_ELEC_POTL"
   },
   "subject" : {
-    "reference" : "Patient/1011537977V693883",
+    "reference" : "https://api.va.gov/services/fhir/v0/r4/Patient/1011537977V693883",
     "display" : "Ms. Carlita746 Kautzer186"
   },
   "effectiveDateTime" : "2015-02-19T09:30:35+01:00",

--- a/patient-generated-data-synthetic/src/test/resources/observation/satO2.json
+++ b/patient-generated-data-synthetic/src/test/resources/observation/satO2.json
@@ -55,7 +55,7 @@
     "text" : "Oxygen saturation in Arterial blood"
   },
   "subject" : {
-    "reference" : "Patient/1011537977V693883"
+    "reference" : "https://api.va.gov/services/fhir/v0/r4/Patient/1011537977V693883"
   },
   "effectiveDateTime" : "2014-12-05T09:30:10+01:00",
   "valueQuantity" : {

--- a/patient-generated-data-synthetic/src/test/resources/observation/satO2.json
+++ b/patient-generated-data-synthetic/src/test/resources/observation/satO2.json
@@ -51,7 +51,8 @@
         "code" : "150456",
         "display" : "MDC_PULS_OXIM_SAT_O2"
       }
-    ]
+    ],
+    "text" : "Oxygen saturation in Arterial blood"
   },
   "subject" : {
     "reference" : "Patient/1011537977V693883"

--- a/patient-generated-data-synthetic/src/test/resources/patient/1000000.json
+++ b/patient-generated-data-synthetic/src/test/resources/patient/1000000.json
@@ -1,6 +1,6 @@
 {
-  "resourceType" : "Patient",
   "id" : "1000000",
+  "resourceType" : "Patient",
   "text" : {
     "status" : "generated",
     "div" : "<div></div>"
@@ -24,11 +24,11 @@
   "name" : [
     {
       "use" : "usual",
+      "text" : "Mr. John100 Smith100",
       "family" : "Smith100",
       "given" : [
         "John100"
-      ],
-      "text" : "Mr. John100 Smith100"
+      ]
     }
   ],
   "telecom" : [

--- a/patient-generated-data-synthetic/src/test/resources/patient/2000000.json
+++ b/patient-generated-data-synthetic/src/test/resources/patient/2000000.json
@@ -1,6 +1,6 @@
 {
-  "resourceType" : "Patient",
   "id" : "2000000",
+  "resourceType" : "Patient",
   "text" : {
     "status" : "generated",
     "div" : "<div></div>"
@@ -74,7 +74,8 @@
         "system" : "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
         "code" : "M"
       }
-    ]
+    ],
+    "text" : "Legally married"
   },
   "multipleBirthBoolean" : false,
   "contact" : [

--- a/patient-generated-data-synthetic/src/test/resources/patient/3000000.json
+++ b/patient-generated-data-synthetic/src/test/resources/patient/3000000.json
@@ -1,6 +1,6 @@
 {
-  "resourceType" : "Patient",
   "id" : "3000000",
+  "resourceType" : "Patient",
   "text" : {
     "status" : "generated",
     "div" : "<div></div>"
@@ -64,7 +64,8 @@
         "code" : "UNK",
         "display" : "unknown"
       }
-    ]
+    ],
+    "text" : "unknown"
   },
   "multipleBirthBoolean" : false
 }

--- a/patient-generated-data-synthetic/src/test/resources/questionnaire-response/3141.json
+++ b/patient-generated-data-synthetic/src/test/resources/questionnaire-response/3141.json
@@ -9,10 +9,10 @@
   "subject" : {
     "reference" : "Patient/1011537977V693883"
   },
+  "authored" : "2013-02-19T14:15:00-05:00",
   "author" : {
     "reference" : "Practitioner/1000000"
   },
-  "authored" : "2013-02-19T14:15:00-05:00",
   "item" : [
     {
       "linkId" : "1",

--- a/patient-generated-data-synthetic/src/test/resources/questionnaire-response/3141.json
+++ b/patient-generated-data-synthetic/src/test/resources/questionnaire-response/3141.json
@@ -7,11 +7,11 @@
   },
   "status" : "completed",
   "subject" : {
-    "reference" : "Patient/1011537977V693883"
+    "reference" : "https://api.va.gov/services/fhir/v0/r4/Patient/1011537977V693883"
   },
   "authored" : "2013-02-19T14:15:00-05:00",
   "author" : {
-    "reference" : "Practitioner/1000000"
+    "reference" : "https://api.va.gov/services/fhir/v0/r4/Practitioner/I2-6NVSMKEGQKNB3KRDXBGE7NRIEY000000"
   },
   "item" : [
     {

--- a/patient-generated-data-synthetic/src/test/resources/questionnaire-response/c18qr.json
+++ b/patient-generated-data-synthetic/src/test/resources/questionnaire-response/c18qr.json
@@ -1,0 +1,65 @@
+{
+  "resourceType" : "QuestionnaireResponse",
+  "id" : "c18qr",
+  "meta" : {
+    "tag" : [
+      {
+        "system" : "https://api.va.gov/services/pgd",
+        "code" : "66a5960c-68ee-4689-88ae-4c7cccf7ca79",
+        "display" : "TEST APP"
+      },
+      {
+        "system" : "https://veteran.apps.va.gov/appointments/v1",
+        "code" : "202008211400983000082100000000000000"
+      }
+    ]
+  },
+  "text" : {
+    "status" : "generated",
+    "div" : "<div><h1>Pre-Visit Questionnaire</h1></div>"
+  },
+  "questionnaire" : "Questionnaire/c18",
+  "status" : "completed",
+  "subject" : {
+    "reference" : "https://api.va.gov/services/fhir/v0/r4/Patient/1008596379V859838"
+  },
+  "authored" : "2020-08-20",
+  "item" : [
+    {
+      "linkId" : "01",
+      "text" : "What is the reason for this appointment?",
+      "answer" : [
+        {
+          "valueString" : "Eye is hurting"
+        }
+      ]
+    },
+    {
+      "linkId" : "02",
+      "text" : "Are there any additional details you'd like to share with your provider about this appointment?",
+      "answer" : [
+        {
+          "valueString" : "cant look into the sun"
+        }
+      ]
+    },
+    {
+      "linkId" : "03",
+      "text" : "Are there any life events that are positively or negatively affecting your health?",
+      "answer" : [
+        {
+          "valueString" : "no"
+        }
+      ]
+    },
+    {
+      "linkId" : "04",
+      "text" : "Do you have other questions you want to ask your provider?",
+      "answer" : [
+        {
+          "valueString" : "Is this covered by my VA Benfits?"
+        }
+      ]
+    }
+  ]
+}

--- a/patient-generated-data-synthetic/src/test/resources/questionnaire-response/c18qr.json
+++ b/patient-generated-data-synthetic/src/test/resources/questionnaire-response/c18qr.json
@@ -23,7 +23,7 @@
   "subject" : {
     "reference" : "https://api.va.gov/services/fhir/v0/r4/Patient/1008596379V859838"
   },
-  "authored" : "2020-08-20",
+  "authored" : "2020-08-20T22:26:06.453127500Z",
   "item" : [
     {
       "linkId" : "01",

--- a/patient-generated-data-synthetic/src/test/resources/questionnaire-response/f201.json
+++ b/patient-generated-data-synthetic/src/test/resources/questionnaire-response/f201.json
@@ -6,10 +6,10 @@
     "div" : "<div></div>"
   },
   "status" : "completed",
+  "authored" : "2013-06-18T00:00:00+01:00",
   "author" : {
     "reference" : "Patient/1011537977V693883"
   },
-  "authored" : "2013-06-18T00:00:00+01:00",
   "item" : [
     {
       "linkId" : "1",

--- a/patient-generated-data-synthetic/src/test/resources/questionnaire-response/f201.json
+++ b/patient-generated-data-synthetic/src/test/resources/questionnaire-response/f201.json
@@ -6,9 +6,12 @@
     "div" : "<div></div>"
   },
   "status" : "completed",
+  "subject" : {
+    "reference" : "https://api.va.gov/services/fhir/v0/r4/Patient/1011537977V693883"
+  },
   "authored" : "2013-06-18T00:00:00+01:00",
   "author" : {
-    "reference" : "Patient/1011537977V693883"
+    "reference" : "https://api.va.gov/services/fhir/v0/r4/Patient/1011537977V693883"
   },
   "item" : [
     {

--- a/patient-generated-data-synthetic/src/test/resources/questionnaire/c18.json
+++ b/patient-generated-data-synthetic/src/test/resources/questionnaire/c18.json
@@ -4,9 +4,9 @@
   "meta" : {
     "tag" : [
       {
-        "system" : "https://wiki.mobilehealth.va.gov/display/PGDMS/Client+Provenance+Mapping",
-        "code" : "vagov-a0e116eb-faa1-4703-aafe-1a270128607a",
-        "display" : "VA GOV CLIPBOARD"
+        "system" : "https://api.va.gov/services/pgd",
+        "code" : "66a5960c-68ee-4689-88ae-4c7cccf7ca79",
+        "display" : "TEST APP"
       }
     ]
   },
@@ -21,38 +21,18 @@
     },
     {
       "linkId" : "02",
-      "text" : "What do I want to talk about at this appointment?",
+      "text" : "Are there any additional details you'd like to share with your provider about this appointment?",
       "type" : "text"
     },
     {
       "linkId" : "03",
-      "text" : "I have new symptoms.",
-      "type" : "boolean"
+      "text" : "Are there any life events that are positively or negatively affecting your health?",
+      "type" : "text"
     },
     {
       "linkId" : "04",
-      "text" : "I have medication questions.",
-      "type" : "boolean"
-    },
-    {
-      "linkId" : "05",
-      "text" : "I have questions about my diagnosis.",
-      "type" : "boolean"
-    },
-    {
-      "linkId" : "06",
-      "text" : "I have questions about my tests.",
-      "type" : "boolean"
-    },
-    {
-      "linkId" : "07",
-      "text" : "I have questions about my treatment plans.",
-      "type" : "boolean"
-    },
-    {
-      "linkId" : "08",
-      "text" : "I have other concerns or life issues to discuss.",
-      "type" : "boolean"
+      "text" : "Do you have other questions you want to ask your provider?",
+      "type" : "text"
     }
   ]
 }

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import lombok.experimental.Delegate;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import com.google.common.collect.Streams;
 
 @ControllerAdvice
 public class QuestionnaireResponseIncludesIcnMajig implements ResponseBodyAdvice<Object> {
@@ -18,8 +19,9 @@ public class QuestionnaireResponseIncludesIcnMajig implements ResponseBodyAdvice
           .extractResources(bundle -> bundle.entry().stream().map(AbstractEntry::resource))
           .extractIcns(
               body ->
-                  Stream.concat(
+                  Streams.concat(
                       Stream.ofNullable(IncludesIcnMajig.icn(body.subject())),
-                      Stream.ofNullable(IncludesIcnMajig.icn(body.author()))))
+                      Stream.ofNullable(IncludesIcnMajig.icn(body.author())),
+                      Stream.ofNullable(IncludesIcnMajig.icn(body.source()))))
           .build();
 }

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/questionnaireresponse/QuestionnaireResponseIncludesIcnMajig.java
@@ -1,5 +1,6 @@
 package gov.va.api.health.patientgenerateddata.questionnaireresponse;
 
+import com.google.common.collect.Streams;
 import gov.va.api.health.patientgenerateddata.IncludesIcnMajig;
 import gov.va.api.health.r4.api.bundle.AbstractEntry;
 import gov.va.api.health.r4.api.resources.QuestionnaireResponse;
@@ -7,7 +8,6 @@ import java.util.stream.Stream;
 import lombok.experimental.Delegate;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
-import com.google.common.collect.Streams;
 
 @ControllerAdvice
 public class QuestionnaireResponseIncludesIcnMajig implements ResponseBodyAdvice<Object> {


### PR DESCRIPTION
https://vajira.max.gov/browse/API-4145

- Populate `subject` as patient on each `QuestionnaireResponse`
- Use fully-qualified links to patient and practitioner
- Deserialize each message with the FHIR java model, then write it back out. (Hence the new `text` field in several places, and some fields shifting order)
- Update `Questionnaire` `c18` to match [markdown](https://github.com/department-of-veterans-affairs/health-apis-patient-generated-data/blob/API-000-mapping/mapping/questionnaire.md), and add a corresponding `QuestionnaireResponse`