### PR TITLE
API-4161 IncludesIcnMajig incorrectly joins ICNs for single resource	

### DIFF
--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
@@ -56,7 +56,7 @@ public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> 
       ServerHttpRequest unused4,
       ServerHttpResponse serverHttpResponse) {
     if (type.isInstance(payload)) {
-      String users = extractIcns.apply((T) payload).collect(joining(","));
+      String users = extractIcns.apply((T) payload).distinct().collect(joining(","));
       users = users.isBlank() ? "NONE" : users;
       addHeader(serverHttpResponse, users);
       return payload;

--- a/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
+++ b/patient-generated-data/src/main/java/gov/va/api/health/patientgenerateddata/IncludesIcnMajig.java
@@ -1,8 +1,9 @@
 package gov.va.api.health.patientgenerateddata;
 
+import static java.util.stream.Collectors.joining;
+
 import gov.va.api.health.r4.api.elements.Reference;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.NonNull;
@@ -55,7 +56,7 @@ public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> 
       ServerHttpRequest unused4,
       ServerHttpResponse serverHttpResponse) {
     if (type.isInstance(payload)) {
-      String users = extractIcns.apply((T) payload).collect(Collectors.joining());
+      String users = extractIcns.apply((T) payload).collect(joining(","));
       users = users.isBlank() ? "NONE" : users;
       addHeader(serverHttpResponse, users);
       return payload;
@@ -67,7 +68,7 @@ public final class IncludesIcnMajig<T, B> implements ResponseBodyAdvice<Object> 
               .apply((B) payload)
               .flatMap(resource -> extractIcns.apply(resource))
               .distinct()
-              .collect(Collectors.joining(","));
+              .collect(joining(","));
       users = users.isBlank() ? "NONE" : users;
       addHeader(serverHttpResponse, users);
       return payload;


### PR DESCRIPTION
```
$ curl -ksi -H "Authorization: Bearer $TOKEN" https://blue.qa.lighthouse.va.gov/pgd/v0/r4/QuestionnaireResponse/f003043a-9047-4c3a-b15b-a26c67f4e723
HTTP/2 403
date: Fri, 18 Dec 2020 19:25:26 GMT
content-type: application/json
server: nginx/1.19.2
vary: Accept-Encoding
x-va-includes-icn: 1011537977V6938831011537977V693883
pragma: no-cache
cache-control: no-cache, no-store
x-kong-upstream-latency: 34
x-kong-proxy-latency: 79
via: kong/2.0.4
strict-transport-security: max-age=15724800; includeSubDomains
```