### PR TITLE
API-5196 add missing mapper for ITs

### DIFF
--- a/patient-generated-data-tests/local-docker-image
+++ b/patient-generated-data-tests/local-docker-image
@@ -28,6 +28,7 @@ run() {
     --rm \
     --network="host" \
     -e K8S_ENVIRONMENT=${ENV:-local} \
+    -e K8S_LOAD_BALANCER=${LB:-localhost:8095} \
     -e MAGIC_ACCESS_TOKEN=nope \
      vasdvp/health-apis-patient-generated-data-tests:latest $@
 }

--- a/patient-generated-data-tests/pom.xml
+++ b/patient-generated-data-tests/pom.xml
@@ -28,12 +28,6 @@
     </dependency>
     <dependency>
       <groupId>gov.va.api.health</groupId>
-      <artifactId>patient-generated-data</artifactId>
-      <version>${project.version}</version>
-      <classifier>library</classifier>
-    </dependency>
-    <dependency>
-      <groupId>gov.va.api.health</groupId>
       <artifactId>patient-generated-data-synthetic</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/patient-generated-data-tests/pom.xml
+++ b/patient-generated-data-tests/pom.xml
@@ -31,7 +31,6 @@
       <artifactId>patient-generated-data</artifactId>
       <version>${project.version}</version>
       <classifier>library</classifier>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>gov.va.api.health</groupId>

--- a/patient-generated-data-tests/src/main/docker/assembly.xml
+++ b/patient-generated-data-tests/src/main/docker/assembly.xml
@@ -11,8 +11,6 @@
       <outputDirectory/>
       <includes>
         <include>**/junit-platform-console-standalone.jar</include>
-        <include>**/patient-generated-data-library.jar</include>
-        <include>**/patient-generated-data-library-*.jar</include>
         <include>**/patient-generated-data-tests-*.jar</include>
       </includes>
       <useDefaultExcludes>true</useDefaultExcludes>

--- a/patient-generated-data-tests/src/main/docker/assembly.xml
+++ b/patient-generated-data-tests/src/main/docker/assembly.xml
@@ -10,8 +10,10 @@
       <directory>${project.build.directory}</directory>
       <outputDirectory/>
       <includes>
-        <include>**/patient-generated-data-tests-*.jar</include>
         <include>**/junit-platform-console-standalone.jar</include>
+        <include>**/patient-generated-data-library.jar</include>
+        <include>**/patient-generated-data-library-*.jar</include>
+        <include>**/patient-generated-data-tests-*.jar</include>
       </includes>
       <useDefaultExcludes>true</useDefaultExcludes>
     </fileSet>

--- a/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/RequestUtils.java
+++ b/patient-generated-data-tests/src/test/java/gov/va/api/health/patientgenerateddata/tests/RequestUtils.java
@@ -4,7 +4,8 @@ import static gov.va.api.health.patientgenerateddata.tests.SystemDefinitions.sys
 import static gov.va.api.health.sentinel.ExpectedResponse.logAllWithTruncatedBody;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.va.api.health.patientgenerateddata.JacksonMapperConfig;
+import gov.va.api.health.autoconfig.configuration.JacksonConfig;
+import gov.va.api.health.r4.api.resources.Resource;
 import gov.va.api.health.sentinel.ExpectedResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.Method;
@@ -14,7 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RequestUtils {
-  public static final ObjectMapper MAPPER = JacksonMapperConfig.createMapper();
+  public static final ObjectMapper MAPPER =
+      JacksonConfig.createMapper().registerModule(new Resource.ResourceModule());
 
   private static final String INTERNAL_R4_PATH = "management/r4/";
 


### PR DESCRIPTION
```
10:38:15    JUnit Jupiter:PatientIT:read_notMe()
10:38:15      MethodSource [className = 'gov.va.api.health.patientgenerateddata.tests.PatientIT', methodName = 'read_notMe', methodParameterTypes = '']
10:38:15      => java.lang.NoClassDefFoundError: gov/va/api/health/patientgenerateddata/JacksonMapperConfig
10:38:15         gov.va.api.health.patientgenerateddata.tests.RequestUtils.<clinit>(RequestUtils.java:17)
10:38:15         gov.va.api.health.patientgenerateddata.tests.PatientIT.read_notMe(PatientIT.java:36)
10:38:15         java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
10:38:15         java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
10:38:15         java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
10:38:15         [...]
10:38:15       Caused by: java.lang.ClassNotFoundException: gov.va.api.health.patientgenerateddata.JacksonMapperConfig
10:38:15         java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:435)
10:38:15         java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
10:38:15         java.base/java.net.FactoryURLClassLoader.loadClass(URLClassLoader.java:855)
10:38:15         java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
10:38:15         [...]
```